### PR TITLE
Typo fix

### DIFF
--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -855,7 +855,7 @@ contract TokenizedStrategy {
                     // Make sure we are withen the acceptable range.
                     require(
                         loss <= (assets * maxLoss) / MAX_BPS,
-                        "to much loss"
+                        "too much loss"
                     );
                 }
                 // Lower the amount to be withdrawn.
@@ -1459,8 +1459,8 @@ contract TokenizedStrategy {
         uint256 _profitMaxUnlockTime
     ) external onlyManagement {
         // Must be greater than 0, and less than a year.
-        require(_profitMaxUnlockTime != 0, "to short");
-        require(_profitMaxUnlockTime <= SECONDS_PER_YEAR, "to long");
+        require(_profitMaxUnlockTime != 0, "too short");
+        require(_profitMaxUnlockTime <= SECONDS_PER_YEAR, "too long");
         _strategyStorage().profitMaxUnlockTime = uint32(_profitMaxUnlockTime);
 
         emit UpdateProfitMaxUnlockTime(_profitMaxUnlockTime);

--- a/src/test/CustomImplementation.t.sol
+++ b/src/test/CustomImplementation.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 import "forge-std/console.sol";
 import {Setup, IMockStrategy} from "./utils/Setup.sol";
 
-contract CutsomImplementationsTest is Setup {
+contract CustomImplementationsTest is Setup {
     function setUp() public override {
         super.setUp();
     }


### PR DESCRIPTION
## Description

Fixing typo like `to short to long` to `too short too long` and `CutsomImplementationTest` to `CustomImplementationTest`.

Fixes # fixing typo

## Checklist

- [x] I have run solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
