### PR TITLE
fix: erroneous profit and loss accounting in specification

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -100,8 +100,8 @@ The strategy will evaluate profit and losses from the yield generating activitie
 
 This is done comparing the current totalAssets of the strategy with the amount returned from _harvestAndReport()
 
-If totalAssets < newTotalAssets: the vault will record a loss
-If totalAssets > newTotalAssets: the vault will record a profit
+If totalAssets < newTotalAssets: the vault will record a profit
+If totalAssets > newTotalAssets: the vault will record a loss
 
 Both loss and profit will impact strategy's totalAssets, increasing if there are profits, decreasing  if there are losses.
 


### PR DESCRIPTION
## Description
In the specified file: https://github.com/yearn/tokenized-strategy/blob/master/SPECIFICATION.md
At lines: 103, 104
It mentions that:
```
If totalAssets < newTotalAssets: the vault will record a loss
If totalAssets > newTotalAssets: the vault will record a profit
```
which should be :
```
If totalAssets < newTotalAssets: the vault will record a profit
If totalAssets > newTotalAssets: the vault will record a loss
```


Fixes #61 

## Checklist

- [x] I have run solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
