### PR TITLE
build: update modifiers

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -13,6 +13,8 @@
       "not-rely-on-time": "off",
       "private-vars-leading-underscore": "off",
       "reason-string": ["warn", { "maxLength": 64 }],
-      "no-console": "off"
+      "no-console": "off",
+      "var-name-mixedcase": "off",
+      "func-name-mixedcase": "off"
     }
   }

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ remappings = [
 fs_permissions = [{ access = "read", path = "./"}]
 
 [fuzz]
-runs = 10_0
+runs = 10_00
 max_test_rejects = 1_000_000
 
 [invariant]

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ remappings = [
 fs_permissions = [{ access = "read", path = "./"}]
 
 [fuzz]
-runs = 10_00
+runs = 10_000
 max_test_rejects = 1_000_000
 
 [invariant]

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ remappings = [
 fs_permissions = [{ access = "read", path = "./"}]
 
 [fuzz]
-runs = 10_000
+runs = 10_0
 max_test_rejects = 1_000_000
 
 [invariant]

--- a/src/BaseTokenizedStrategy.sol
+++ b/src/BaseTokenizedStrategy.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.18;
 import {ITokenizedStrategy} from "./interfaces/ITokenizedStrategy.sol";
 
 /**
- * @title YearnV3 Base Tokenized Strategy
+ * @title Yearn Base Tokenized Strategy
  * @author yearn.finance
  * @notice
  *  BaseTokenizedStrategy implements all of the required functionality to

--- a/src/BaseTokenizedStrategy.sol
+++ b/src/BaseTokenizedStrategy.sol
@@ -63,8 +63,17 @@ abstract contract BaseTokenizedStrategy {
         _;
     }
 
+    /**
+     * @dev Use to assure that the call is coming from either the strategies
+     * management or the emergency admin.
+     */
+    modifier onlyEmergencyAuthorized() {
+        TokenizedStrategy.isEmergencyAuthorized(msg.sender);
+        _;
+    }
+
     function _onlySelf() internal view {
-        require(msg.sender == address(this), "!Authorized");
+        require(msg.sender == address(this), "!self");
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -884,7 +884,7 @@ contract TokenizedStrategy {
         uint256 maxLoss
     ) private returns (uint256) {
         require(receiver != address(0), "ZERO ADDRESS");
-        require(maxLoss <= MAX_BPS, "max loss");
+        require(maxLoss <= MAX_BPS, "exceeds MAX_BPS");
 
         // Spend allowance if applicable.
         if (msg.sender != owner) {

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1,6 +1,52 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.18;
 
+/**$$$$$$$$$$$$$$$$$$$$$$$$$$$&Mr/|1+~>>iiiiiiiiiii>~+{|tuMW$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$$$$$$$$B#j]->iiiiiiiiiiiiiiiiiiiiiiiiiiii>-?f*B$$$$$$$$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$$$$@zj}~iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii~}fv@$$$$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$@z(+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii+)zB$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$Mf~iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii~t#@$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$@u[iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii?n@$$$$$$$$$$$$$
+$$$$$$$$$$$@z]iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii?u@$$$$$$$$$$$
+$$$$$$$$$$v]iiiiiiiiiiiiiiii,.';iiiiiiiiiiiiiiiiiiiiiiiiii;'."iiiiiiiiiiiiiiii?u$$$$$$$$$$
+$$$$$$$$%)>iiiiiiiiiiiiiii,.    ';iiiiiiiiiiiiiiiiiiiiii;'    ."iiiiiiiiiiiiiiii1%$$$$$$$$
+$$$$$$$c~iiiiiiiiiiiiiii,.        ';iiiiiiiiiiiiiiiiii;'        ."iiiiiiiiiiiiiii~u$$$$$$$
+$$$$$B/>iiiiiiiiiiiiii!'            `IiiiiiiiiiiiiiiI`            .Iiiiiiiiiiiiiii>|%$$$$$
+$$$$@)iiiiiiiiiiiiiiiii;'             `Iiiiiiiiiiil`             ';iiiiiiiiiiiiiiiii}@$$$$
+$$$B|iiiiiiiiiiiiiiiiiiii;'             `Iiiiiiil`             ';iiiiiiiiiiiiiiiiiiii1B$$$
+$$@)iiiiiiiiiiiiiiiiiiiiiii:'             `;iiI`             ':iiiiiiiiiiiiiiiiiiiiiii{B$$
+$$|iiiiiiiiiiiiiiiiiiiiiiiiii;'             ``             ':iiiiiiiiiiiiiiiiiiiiiiiiii1$$
+$v>iiiiiiiiiiiiiiiiiiiiiiiiiiii:'                        ':iiiiiiiiiiiiiiiiiiiiiiiiiiii>x$
+&?iiiiiiiiiiiiiiiiiiiiiiiiiiiiiii:'                    .,iiiiiiiiiiiiiiiiiiiiiiiiiiiiiii-W
+ziiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii:'                .,iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiv
+-iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii:'            .,iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii-
+<iiiiiiiiiiiiiiiiiiii!.':iiiiiiiiiiiiii,          "iiiiiiiiiiiiii;'.Iiiiiiiiiiiiiiiiiiiii<
+iiiiiiiiiiiiiiiiiiiii'   ';iiiiiiiiiiiii          Iiiiiiiiiiiii;'   .iiiiiiiiiiiiiiiiiiiii
+iiiiiiiiiiiiiiiiiiii,      ';iiiiiiiiiii          IiiiiiiiiiiI`      `iiiiiiiiiiiiiiiiiiii
+iiiiiiiiiiiiiiiiiiii.        `Iiiiiiiiii          Iiiiiiiii!`         !iiiiiiiiiiiiiiiiiii
+iiiiiiiiiiiiiiiiiii;          :iiiiiiiii          Iiiiiiiii!          ,iiiiiiiiiiiiiiiiiii
+iiiiiiiiiiiiiiiiiii,          iiiiiiiiii          Iiiiiiiiii.         ^iiiiiiiiiiiiiiiiiii
+<iiiiiiiiiiiiiiiiii,          iiiiiiiiii          Iiiiiiiiii'         ^iiiiiiiiiiiiiiiiii<
+-iiiiiiiiiiiiiiiiii;          Iiiiiiiiii          Iiiiiiiiii.         "iiiiiiiiiiiiiiiiii-
+ziiiiiiiiiiiiiiiiiii.         'iiiiiiiii''''''''''liiiiiiii^          liiiiiiiiiiiiiiiiiiv
+&?iiiiiiiiiiiiiiiiii^          ^iiiiiiiiiiiiiiiiiiiiiiiiii,          `iiiiiiiiiiiiiiiiii_W
+$u>iiiiiiiiiiiiiiiiii.          `!iiiiiiiiiiiiiiiiiiiiiii^          .liiiiiiiiiiiiiiiiiir$
+$$(iiiiiiiiiiiiiiiiii;.          ."iiiiiiiiiiiiiiiiiiii,.           :iiiiiiiiiiiiiiiiii}$$
+$$@{iiiiiiiiiiiiiiiiii;.           .`:iiiiiiiiiiiiii;^.            :iiiiiiiiiiiiiiiiii}B$$
+$$$B)iiiiiiiiiiiiiiiiii!'              '`",::::,"`'.             .Iiiiiiiiiiiiiiiiiii{%$$$
+$$$$@1iiiiiiiiiiiiiiiiiii,.                                     ^iiiiiiiiiiiiiiiiiii[@$$$$
+$$$$$B|>iiiiiiiiiiiiiiiiii!^.                                 `liiiiiiiiiiiiiiiiii>)%$$$$$
+$$$$$$$c~iiiiiiiiiiiiiiiiiiii"'                            ."!iiiiiiiiiiiiiiiiiii~n$$$$$$$
+$$$$$$$$B)iiiiiiiiiiiiiiiiiiiii!,`.                    .'"liiiiiiiiiiiiiiiiiiiii1%$$$$$$$$
+$$$$$$$$$@u]iiiiiiiiiiiiiiiiiiiiiiil,^`'..      ..''^,liiiiiiiiiiiiiiiiiiiiiii-x@$$$$$$$$$
+$$$$$$$$$$$@v?iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii-x$$$$$$$$$$$$
+$$$$$$$$$$$$$@n?iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii-rB$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$/~iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii<\*@$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$Bc1~iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii~{v%$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$$$$Bvf]<iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii<]tuB$$$$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$$$$$$$$%zt-+>iiiiiiiiiiiiiiiiiiiiiiiiiiiii+_tc%$$$$$$$$$$$$$$$$$$$$$$$$$
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$W#u/|{+~>iiiiiiiiiiii><+{|/n#W$$$$$$$$$$$$$$$$$$$$$$$$$$$$*/
+
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -9,7 +55,7 @@ import {IFactory} from "./interfaces/IFactory.sol";
 import {IBaseTokenizedStrategy} from "./interfaces/IBaseTokenizedStrategy.sol";
 
 /**
- * @title YearnV3 Tokenized Strategy
+ * @title Yearn Tokenized Strategy
  * @author yearn.finance
  * @notice
  *  This TokenizedStrategy can be used by anyone wishing to easily build
@@ -838,6 +884,8 @@ contract TokenizedStrategy {
         uint256 maxLoss
     ) private returns (uint256) {
         require(receiver != address(0), "ZERO ADDRESS");
+        require(maxLoss <= MAX_BPS, "max loss");
+
         // Spend allowance if applicable.
         if (msg.sender != owner) {
             _spendAllowance(owner, msg.sender, shares);

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -22,6 +22,11 @@ interface IEvents {
     event UpdateKeeper(address indexed newKeeper);
 
     /**
+     * @notice Emitted when the 'emergencyAdmin' address is updated to 'newEmergencyAdmin'.
+     */
+    event UpdateEmergencyAdmin(address indexed newEmergencyAdmin);
+
+    /**
      * @notice Emitted whent the 'performaneFee' is updtaed to 'newPerformanceFee'.
      */
     event UpdatePerformanceFee(uint16 newPerformanceFee);

--- a/src/interfaces/ITokenizedStrategy.sol
+++ b/src/interfaces/ITokenizedStrategy.sol
@@ -17,6 +17,8 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
 
     event UpdateKeeper(address indexed newKeeper);
 
+    event UpdateEmergencyAdmin(address indexed newEmergencyAdmin);
+
     event UpdatePerformanceFee(uint16 newPerformanceFee);
 
     event UpdatePerformanceFeeRecipient(
@@ -30,8 +32,8 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
     event Reported(
         uint256 profit,
         uint256 loss,
-        uint256 performanceFees,
-        uint256 protocolFees
+        uint256 protocolFees,
+        uint256 performanceFees
     );
 
     /*//////////////////////////////////////////////////////////////
@@ -68,11 +70,13 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
                             MODIFIERS
     //////////////////////////////////////////////////////////////*/
 
-    function isKeeperOrManagement(address _sender) external view;
+    function isManagement(address _sender) external view returns (bool);
 
-    function isManagement(address _sender) external view;
+    function isKeeperOrManagement(address _sender) external view returns (bool);
 
-    function isShutdown() external view returns (bool);
+    function isEmergencyAuthorized(
+        address _sender
+    ) external view returns (bool);
 
     /*//////////////////////////////////////////////////////////////
                         KEEPERS FUNCTIONS
@@ -110,6 +114,8 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
 
     function keeper() external view returns (address);
 
+    function emergencyAdmin() external view returns (address);
+
     function performanceFee() external view returns (uint16);
 
     function performanceFeeRecipient() external view returns (address);
@@ -122,6 +128,8 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
 
     function lastReport() external view returns (uint256);
 
+    function isShutdown() external view returns (bool);
+
     /*//////////////////////////////////////////////////////////////
                             SETTERS
     //////////////////////////////////////////////////////////////*/
@@ -131,6 +139,8 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
     function acceptManagement() external;
 
     function setKeeper(address _keeper) external;
+
+    function setEmergencyAdmin(address _emergencyAdmin) external;
 
     function setPerformanceFee(uint16 _performanceFee) external;
 

--- a/src/test/AccessControl.t.sol
+++ b/src/test/AccessControl.t.sol
@@ -109,7 +109,7 @@ contract AccesssControlTest is Setup {
         address _management = strategy.management();
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!management");
         strategy.setPendingManagement(address(69));
 
         assertEq(strategy.management(), _management);
@@ -121,7 +121,7 @@ contract AccesssControlTest is Setup {
         assertEq(strategy.management(), _management);
         assertEq(strategy.pendingManagement(), _address);
 
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!pending");
         vm.prank(management);
         strategy.acceptManagement();
     }
@@ -132,7 +132,7 @@ contract AccesssControlTest is Setup {
         address _keeper = strategy.keeper();
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!management");
         strategy.setKeeper(address(69));
 
         assertEq(strategy.keeper(), _keeper);
@@ -148,7 +148,7 @@ contract AccesssControlTest is Setup {
         uint256 _performanceFee = strategy.performanceFee();
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!management");
         strategy.setPerformanceFee(_amount);
 
         assertEq(strategy.performanceFee(), _performanceFee);
@@ -170,7 +170,7 @@ contract AccesssControlTest is Setup {
         address _performanceFeeRecipient = strategy.performanceFeeRecipient();
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!management");
         strategy.setPerformanceFeeRecipient(address(69));
 
         vm.prank(management);
@@ -193,7 +193,7 @@ contract AccesssControlTest is Setup {
         uint256 profitMaxUnlockTime = strategy.profitMaxUnlockTime();
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!management");
         strategy.setProfitMaxUnlockTime(amount);
 
         assertEq(strategy.profitMaxUnlockTime(), profitMaxUnlockTime);
@@ -207,18 +207,18 @@ contract AccesssControlTest is Setup {
     }
 
     function test_shutdown_reverts(address _address) public {
-        vm.assume(_address != management);
+        vm.assume(_address != management && _address != emergencyAdmin);
         assertTrue(!strategy.isShutdown());
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!emergency authorized");
         strategy.shutdownStrategy();
 
         assertTrue(!strategy.isShutdown());
     }
 
     function test_emergencyWithdraw_reverts(address _address) public {
-        vm.assume(_address != management);
+        vm.assume(_address != management && _address != emergencyAdmin);
 
         vm.prank(management);
         strategy.shutdownStrategy();
@@ -226,7 +226,7 @@ contract AccesssControlTest is Setup {
         assertTrue(strategy.isShutdown());
 
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!emergency authorized");
         strategy.emergencyWithdraw(0);
     }
 
@@ -263,11 +263,11 @@ contract AccesssControlTest is Setup {
 
         // doesnt work from random address
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.deployFunds(_amount);
 
         vm.prank(management);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.deployFunds(_amount);
 
         assertEq(asset.balanceOf(address(yieldSource)), 0);
@@ -295,13 +295,13 @@ contract AccesssControlTest is Setup {
 
         // doesnt work from random address
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.freeFunds(_amount);
         (_amount);
 
         // doesnt work from management either
         vm.prank(management);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.freeFunds(_amount);
 
         assertEq(asset.balanceOf(address(strategy)), 0);
@@ -329,12 +329,12 @@ contract AccesssControlTest is Setup {
 
         // doesnt work from random address
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.harvestAndReport();
 
         // doesnt work from management either
         vm.prank(management);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.harvestAndReport();
 
         vm.prank(address(strategy));
@@ -352,7 +352,7 @@ contract AccesssControlTest is Setup {
 
         // doesnt work from random address
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!self");
         strategy.tendThis(_amount);
 
         vm.prank(address(strategy));
@@ -367,7 +367,7 @@ contract AccesssControlTest is Setup {
 
         // doesnt work from random address
         vm.prank(_address);
-        vm.expectRevert("!Authorized");
+        vm.expectRevert("!keeper");
         strategy.tend();
 
         vm.prank(keeper);

--- a/src/test/Shutdown.t.sol
+++ b/src/test/Shutdown.t.sol
@@ -37,9 +37,22 @@ contract ShutdownTest is Setup {
         vm.prank(_address);
         asset.approve(address(strategy), _amount);
 
-        vm.expectRevert("shutdown");
+        vm.expectRevert("ERC4626: deposit more than max");
         vm.prank(_address);
         strategy.deposit(_amount, _address);
+
+        vm.expectRevert("ERC4626: mint more than max");
+        vm.prank(_address);
+        strategy.mint(_amount, _address);
+
+        // Also can't deposit 0.
+        vm.expectRevert("ZERO_SHARES");
+        vm.prank(_address);
+        strategy.deposit(0, _address);
+
+        vm.expectRevert("ZERO_ASSETS");
+        vm.prank(_address);
+        strategy.mint(0, _address);
 
         checkStrategyTotals(strategy, _amount, _amount, 0, _amount);
     }
@@ -64,7 +77,7 @@ contract ShutdownTest is Setup {
         vm.expectEmit(true, true, true, true, address(strategy));
         emit StrategyShutdown();
 
-        vm.prank(management);
+        vm.prank(emergencyAdmin);
         strategy.shutdownStrategy();
 
         assertTrue(strategy.isShutdown());
@@ -75,7 +88,7 @@ contract ShutdownTest is Setup {
         vm.prank(_address);
         asset.approve(address(strategy), _amount);
 
-        vm.expectRevert("shutdown");
+        vm.expectRevert("ERC4626: deposit more than max");
         vm.prank(_address);
         strategy.deposit(_amount, _address);
 
@@ -124,7 +137,7 @@ contract ShutdownTest is Setup {
         vm.prank(_address);
         asset.approve(address(strategy), _amount);
 
-        vm.expectRevert("shutdown");
+        vm.expectRevert("ERC4626: deposit more than max");
         vm.prank(_address);
         strategy.deposit(_amount, _address);
 
@@ -177,7 +190,7 @@ contract ShutdownTest is Setup {
         // Withdra half and make sure it records properly
         uint256 toWithdraw = _amount / 2;
 
-        vm.prank(management);
+        vm.prank(emergencyAdmin);
         strategy.emergencyWithdraw(toWithdraw);
 
         // Make sure it pulled out the correct amount.
@@ -282,7 +295,7 @@ contract ShutdownTest is Setup {
         vm.expectEmit(true, true, true, true, address(strategy));
         emit StrategyShutdown();
 
-        vm.prank(management);
+        vm.prank(emergencyAdmin);
         strategy.shutdownStrategy();
 
         assertTrue(strategy.isShutdown());

--- a/src/test/mocks/IMockStrategy.sol
+++ b/src/test/mocks/IMockStrategy.sol
@@ -32,9 +32,13 @@ interface IMockStrategy is ITokenizedStrategy {
 
     function onlyLetKeepersIn() external;
 
+    function onlyLetEmergencyAdminsIn() external;
+
     function yieldSource() external view returns (address);
 
     function managed() external view returns (bool);
 
     function kept() external view returns (bool);
+
+    function emergentizated() external view returns (bool);
 }

--- a/src/test/mocks/MockStrategy.sol
+++ b/src/test/mocks/MockStrategy.sol
@@ -11,6 +11,7 @@ contract MockStrategy is BaseTokenizedStrategy {
     bool public trigger;
     bool public managed;
     bool public kept;
+    bool public emergentizated;
 
     constructor(
         address _asset,
@@ -68,5 +69,9 @@ contract MockStrategy is BaseTokenizedStrategy {
 
     function onlyLetKeepersIn() public onlyKeepers {
         kept = true;
+    }
+
+    function onlyLetEmergencyAdminsIn() public onlyEmergencyAuthorized {
+        emergentizated = true;
     }
 }

--- a/src/test/utils/Setup.sol
+++ b/src/test/utils/Setup.sol
@@ -25,11 +25,12 @@ contract Setup is ExtendedTest, IEvents {
     TokenizedStrategy public tokenizedStrategy;
 
     // Addresses for different roles we will use repeatedly.
-    address public user = address(10);
-    address public keeper = address(4);
-    address public management = address(1);
-    address public protocolFeeRecipient = address(2);
-    address public performanceFeeRecipient = address(3);
+    address public user = address(1);
+    address public keeper = address(2);
+    address public management = address(3);
+    address public emergencyAdmin = address(4);
+    address public protocolFeeRecipient = address(5);
+    address public performanceFeeRecipient = address(6);
 
     // Integer variables that will be used repeatedly.
     uint256 public decimals = 18;
@@ -64,11 +65,12 @@ contract Setup is ExtendedTest, IEvents {
         vm.label(address(asset), "asset");
         vm.label(management, "management");
         vm.label(address(strategy), "strategy");
+        vm.label(emergencyAdmin, "emergency admin");
         vm.label(address(mockFactory), "mock Factory");
         vm.label(address(yieldSource), "Mock Yield Source");
         vm.label(address(tokenizedStrategy), "tokenized Logic");
-        vm.label(protocolFeeRecipient, "protocolFeeRecipient");
-        vm.label(performanceFeeRecipient, "performanceFeeRecipient");
+        vm.label(protocolFeeRecipient, "Protocol Fee Recipient");
+        vm.label(performanceFeeRecipient, "Performance Fee Recipient");
     }
 
     function setUpStrategy() public returns (address) {
@@ -79,6 +81,8 @@ contract Setup is ExtendedTest, IEvents {
 
         // set keeper
         _strategy.setKeeper(keeper);
+        // set the emergency admin
+        _strategy.setEmergencyAdmin(emergencyAdmin);
         // set treasury
         _strategy.setPerformanceFeeRecipient(performanceFeeRecipient);
         // set management of the strategy
@@ -99,6 +103,8 @@ contract Setup is ExtendedTest, IEvents {
 
         // set keeper
         _strategy.setKeeper(keeper);
+        // set the emergency admin
+        _strategy.setEmergencyAdmin(emergencyAdmin);
         // set treasury
         _strategy.setPerformanceFeeRecipient(performanceFeeRecipient);
         // set management of the strategy
@@ -119,6 +125,8 @@ contract Setup is ExtendedTest, IEvents {
 
         // set keeper
         _strategy.setKeeper(keeper);
+        // set the emergency admin
+        _strategy.setEmergencyAdmin(emergencyAdmin);
         // set treasury
         _strategy.setPerformanceFeeRecipient(performanceFeeRecipient);
         // set management of the strategy


### PR DESCRIPTION
## Description

- Add different revert messages for each modifier.
- add a new emergencyAdmin, getters, setters and modifiers that can shutdown strategy and call emergencyWithdraw
- Emergency Admin defaults to address(0) and must be set manually.
- moved the max checks each to its own function to avoid rounding issues and give correct revert messages.

Fixes # (issue)
#59 

## Checklist

- [ ] I have run solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
