### PR TITLE
feat: lower report costs

### DIFF
--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1225,9 +1225,6 @@ contract TokenizedStrategy {
         S.totalAssets = newTotalAssets;
         S.lastReport = uint96(block.timestamp);
 
-        // Reset lastReport.
-        _strategyStorage().lastReport = uint128(block.timestamp);
-
         // Emit event with info
         emit Reported(
             profit,

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1168,7 +1168,6 @@ contract TokenizedStrategy {
 
             // Check in case else was due to being equal.
             if (loss != 0) {
-                // Add the equivalent shares to the amount to try and burn.
                 // We will try and burn the unlocked shares and as much from any
                 // pending profit still unlocking to offset the loss to prevent any PPS decline post report.
                 sharesToBurn = Math.min(

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1581,8 +1581,11 @@ contract TokenizedStrategy {
 
         // If we are setting to 0 we need to adjust amounts.
         if (_profitMaxUnlockTime == 0) {
-            // Burn all shares if applicable.
-            _burn(S, address(this), S.balances[address(this)]);
+            uint256 shares = S.balances[address(this)];
+            if (shares != 0) {
+                // Burn all shares if applicable.
+                _burn(S, address(this), shares);
+            }
             // Reset unlocking variables
             S.profitUnlockingRate = 0;
             S.fullProfitUnlockDate = 0;

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1093,7 +1093,7 @@ contract TokenizedStrategy {
 
             // We need to get the equivalent amount of shares
             // at the current PPS before any minting or burning.
-            sharesToLock = _convertToShares(S, profit);
+            sharesToLock = _convertToShares(S, profit, Math.Rounding.Down);
 
             // Cache the performance fee.
             uint16 fee = S.performanceFee;
@@ -1174,7 +1174,7 @@ contract TokenizedStrategy {
                     // Cannot burn more than we have.
                     S.balances[address(this)],
                     // Try and burn both the shares already unlocked and the amount for the loss.
-                    _convertToShares(S, loss) + sharesToBurn
+                    _convertToShares(S, loss, Math.Rounding.Down) + sharesToBurn
                 );
             }
 

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1204,8 +1204,8 @@ contract TokenizedStrategy {
             );
         } else {
             // Only setting this to 0 will turn in the desired effect,
-            // no need to update fullProfitUnlockDate.
-            S.profitUnlockingRate = 0;
+            // no need to update profitUnlockingRate.
+            S.fullProfitUnlockDate = 0;
         }
 
         // Update the new total assets value.
@@ -1225,8 +1225,7 @@ contract TokenizedStrategy {
      * @dev Called during reports to burn shares that have been unlocked
      * since the last report.
      *
-     * Will reset the `lastReport` if haven't unlocked the full amount yet
-     * so future calculations remain correct.
+     * Will reset the `lastReport` since this is only called during reports.
      */
     function _burnUnlockedShares(StrategyData storage S) internal {
         uint256 unlocked = _unlockedShares(S);

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -1066,8 +1066,6 @@ contract TokenizedStrategy {
         // Cache storage pointer since its used repeatedly.
         StrategyData storage S = _strategyStorage();
 
-        uint256 oldTotalAssets = S.totalAssets;
-
         // Tell the strategy to report the real total assets it has.
         // It should do all reward selling and redepositing now and
         // account for deployed and loose `asset` so we can accurately
@@ -1076,7 +1074,9 @@ contract TokenizedStrategy {
         uint256 newTotalAssets = IBaseStrategy(address(this))
             .harvestAndReport();
 
-        // Get the amount of shares we need to burn
+        uint256 oldTotalAssets = _totalAssets(S);
+
+        // Get the amount of shares we need to burn from previous reports.
         uint256 sharesToBurn = _unlockedShares(S);
 
         // Initialize variables needed throughout.
@@ -1159,7 +1159,6 @@ contract TokenizedStrategy {
                     _mint(S, protocolFeesRecipient, protocolFeeShares);
                 }
             }
-
         } else {
             // Expect we have a loss.
             unchecked {

--- a/src/test/ProfitLocking.t.sol
+++ b/src/test/ProfitLocking.t.sol
@@ -780,9 +780,9 @@ contract ProfitLockingTest is Setup {
 
         uint256 newAmount = _amount + profit;
 
-        uint256 secondExpectedSharesForFees = strategy.convertToShares(
-            expectedProtocolFee + expectedPerformanceFee
-        );
+        uint256 secondExpectedSharesForFees = (strategy.convertToShares(
+            profit
+        ) * performanceFee) / MAX_BPS;
 
         createAndCheckProfit(
             strategy,
@@ -920,9 +920,9 @@ contract ProfitLockingTest is Setup {
 
         uint256 newAmount = _amount + profit;
 
-        uint256 secondExpectedSharesForFees = strategy.convertToShares(
-            expectedPerformanceFee + expectedProtocolFee
-        );
+        uint256 secondExpectedSharesForFees = (strategy.convertToShares(
+            profit
+        ) * performanceFee) / MAX_BPS;
 
         createAndCheckProfit(
             strategy,
@@ -938,10 +938,7 @@ contract ProfitLockingTest is Setup {
             0,
             newAmount -
                 ((profit - totalExpectedFees) / 2) +
-                strategy.previewWithdraw(
-                    profit - (expectedProtocolFee + expectedPerformanceFee)
-                ) +
-                secondExpectedSharesForFees
+                strategy.convertToShares(profit)
         );
 
         increaseTimeAndCheckBuffer(strategy, profitMaxUnlockTime, 0);

--- a/src/test/ProfitLocking.t.sol
+++ b/src/test/ProfitLocking.t.sol
@@ -921,8 +921,8 @@ contract ProfitLockingTest is Setup {
         uint256 newAmount = _amount + profit;
 
         uint256 secondExpectedSharesForFees = strategy.convertToShares(
-            expectedPerformanceFee
-        ) + strategy.convertToShares(expectedProtocolFee);
+            expectedPerformanceFee + expectedProtocolFee
+        );
 
         createAndCheckProfit(
             strategy,
@@ -1863,6 +1863,116 @@ contract ProfitLockingTest is Setup {
 
         vm.prank(_address);
         strategy.redeem(newAmount - profit, _address, _address);
+
+        checkStrategyTotals(strategy, 0, 0, 0, 0);
+
+        assertEq(strategy.pricePerShare(), wad, "pps reset");
+    }
+
+    function test_buffer_noGainReport(
+        address _address,
+        uint256 _amount,
+        uint16 _profitFactor
+    ) public {
+        _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
+        _profitFactor = uint16(bound(uint256(_profitFactor), 10, MAX_BPS));
+        vm.assume(
+            _address != address(0) &&
+                _address != address(strategy) &&
+                _address != protocolFeeRecipient &&
+                _address != performanceFeeRecipient &&
+                _address != address(yieldSource)
+        );
+        // set fees to 0
+        uint16 protocolFee = 0;
+        uint16 performanceFee = 0;
+        setFees(protocolFee, performanceFee);
+
+        assertEq(strategy.profitUnlockingRate(), 0, "!rate");
+        assertEq(strategy.fullProfitUnlockDate(), 0, "date");
+
+        mintAndDepositIntoStrategy(strategy, _address, _amount);
+
+        // Increase time to simulate interest being earned
+        increaseTimeAndCheckBuffer(strategy, profitMaxUnlockTime, 0);
+
+        uint256 profit = (_amount * _profitFactor) / MAX_BPS;
+
+        uint256 expectedPerformanceFee = (profit * performanceFee) / MAX_BPS;
+        uint256 expectedProtocolFee = (expectedPerformanceFee * protocolFee) /
+            MAX_BPS;
+
+        uint256 totalExpectedFees = expectedPerformanceFee +
+            expectedProtocolFee;
+        createAndCheckProfit(
+            strategy,
+            profit,
+            expectedProtocolFee,
+            expectedPerformanceFee
+        );
+
+        assertEq(strategy.pricePerShare(), wad, "!pps");
+
+        checkStrategyTotals(
+            strategy,
+            _amount + profit,
+            _amount + profit,
+            0,
+            _amount + profit
+        );
+
+        increaseTimeAndCheckBuffer(
+            strategy,
+            profitMaxUnlockTime / 2,
+            (profit - totalExpectedFees) / 2
+        );
+
+        checkStrategyTotals(
+            strategy,
+            _amount + profit,
+            _amount + profit,
+            0,
+            _amount + profit - ((profit - totalExpectedFees) / 2)
+        );
+
+        // Make sure we have active unlocking
+        assertGt(strategy.profitUnlockingRate(), 0);
+        assertGt(strategy.fullProfitUnlockDate(), 0);
+        assertGt(strategy.balanceOf(address(strategy)), 0);
+        uint256 pps = strategy.pricePerShare();
+
+        // Report with no profit or loss
+        vm.prank(keeper);
+        strategy.report();
+
+        // Should be the same as before
+        assertEq(strategy.pricePerShare(), pps, "pps");
+        checkStrategyTotals(
+            strategy,
+            _amount + profit,
+            _amount + profit,
+            0,
+            _amount + profit - ((profit - totalExpectedFees) / 2)
+        );
+
+        increaseTimeAndCheckBuffer(strategy, profitMaxUnlockTime / 2, 0);
+
+        // Everything should be unlocked now.
+        assertRelApproxEq(
+            strategy.pricePerShare(),
+            wad + ((wad * _profitFactor) / MAX_BPS),
+            MAX_BPS
+        );
+        checkStrategyTotals(
+            strategy,
+            _amount + profit,
+            _amount + profit,
+            0,
+            _amount
+        );
+
+        vm.prank(_address);
+        strategy.redeem(_amount, _address, _address);
 
         checkStrategyTotals(strategy, 0, 0, 0, 0);
 


### PR DESCRIPTION
## Description

- improved performance of the `report` function for gas savings.
- only use convertToShares once per report
- Only burn or mint shares to the strategy once during each report based on the end state
- only update lastReport once.

- removes up to 3 extra sstore's

Fixes # (issue)

## Checklist

- [x] I have run solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
- [x] I have updated the SPECIFICATION.md for any relevant changes
