### PR TITLE
fix: max redeem rounding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,8 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	release = v4.8.2
-	branch = v4.8.2
+	release = v4.9.5
+	branch = v4.9.5
 [submodule "lib/erc4626-tests"]
 	path = lib/erc4626-tests
 	url = https://github.com/a16z/erc4626-tests

--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -935,8 +935,8 @@ contract TokenizedStrategy {
             maxRedeem_ = _balanceOf(S, owner);
         } else {
             maxRedeem_ = Math.min(
-                // Use preview withdraw to round up
-                _previewWithdraw(S, maxRedeem_),
+                // Can't redeem more than the balance.
+                _convertToShares(S, maxRedeem_),
                 _balanceOf(S, owner)
             );
         }

--- a/src/test/CustomImplementation.t.sol
+++ b/src/test/CustomImplementation.t.sol
@@ -83,11 +83,13 @@ contract CustomImplementationsTest is Setup {
 
         uint256 before = asset.balanceOf(_address);
         uint256 redeem = strategy.maxRedeem(_address);
+        uint256 conversion = strategy.convertToAssets(_amount);
 
         vm.prank(_address);
         strategy.redeem(redeem, _address, _address, 0);
 
         // We need to give 2 wei rounding buffer
+        assertApproxEq(strategy.convertToAssets(_amount), conversion, 2);
         assertApproxEq(asset.balanceOf(_address) - before, idle, 2);
         assertApproxEq(strategy.availableWithdrawLimit(_address), 0, 2);
         assertApproxEq(strategy.maxWithdraw(_address), 0, 2);

--- a/src/test/CustomImplementation.t.sol
+++ b/src/test/CustomImplementation.t.sol
@@ -40,9 +40,9 @@ contract CustomImplementationsTest is Setup {
 
         // Make sure max withdraw and redeem return the correct amounts
         assertEq(strategy.maxWithdraw(_address), idle);
-        assertEq(strategy.maxRedeem(_address), strategy.previewWithdraw(idle));
+        assertEq(strategy.maxRedeem(_address), strategy.convertToShares(idle));
         assertLe(
-            strategy.maxRedeem(_address),
+            strategy.convertToAssets(strategy.maxRedeem(_address)),
             strategy.availableWithdrawLimit(_address)
         );
 
@@ -67,11 +67,12 @@ contract CustomImplementationsTest is Setup {
 
         // Make sure max withdraw and redeem return the correct amounts
         assertEq(strategy.maxWithdraw(_address), idle);
-        assertEq(strategy.maxRedeem(_address), strategy.previewWithdraw(idle));
+        assertEq(strategy.maxRedeem(_address), strategy.convertToShares(idle));
         assertLe(
-            strategy.maxRedeem(_address),
+            strategy.convertToAssets(strategy.maxRedeem(_address)),
             strategy.availableWithdrawLimit(_address)
         );
+
 
         vm.expectRevert("ERC4626: redeem more than max");
         vm.prank(_address);
@@ -82,10 +83,10 @@ contract CustomImplementationsTest is Setup {
         strategy.withdraw(_amount, _address, _address);
 
         uint256 before = asset.balanceOf(_address);
-        uint256 redeem = strategy.previewWithdraw(idle);
+        uint256 redeem = strategy.maxRedeem(idle);
 
         vm.prank(_address);
-        strategy.redeem(redeem, _address, _address);
+        strategy.redeem(redeem, _address, _address, 0);
 
         // We need to give a i wei rounding buffer
         assertApproxEq(asset.balanceOf(_address) - before, idle, 1);

--- a/src/test/CustomImplementation.t.sol
+++ b/src/test/CustomImplementation.t.sol
@@ -73,7 +73,6 @@ contract CustomImplementationsTest is Setup {
             strategy.availableWithdrawLimit(_address)
         );
 
-
         vm.expectRevert("ERC4626: redeem more than max");
         vm.prank(_address);
         strategy.redeem(_amount, _address, _address);
@@ -83,18 +82,18 @@ contract CustomImplementationsTest is Setup {
         strategy.withdraw(_amount, _address, _address);
 
         uint256 before = asset.balanceOf(_address);
-        uint256 redeem = strategy.maxRedeem(idle);
+        uint256 redeem = strategy.maxRedeem(_address);
 
         vm.prank(_address);
         strategy.redeem(redeem, _address, _address, 0);
 
-        // We need to give a i wei rounding buffer
-        assertApproxEq(asset.balanceOf(_address) - before, idle, 1);
-        assertApproxEq(strategy.availableWithdrawLimit(_address), 0, 1);
-        assertApproxEq(strategy.maxWithdraw(_address), 0, 1);
-        assertApproxEq(strategy.maxRedeem(_address), 0, 1);
+        // We need to give 2 wei rounding buffer
+        assertApproxEq(asset.balanceOf(_address) - before, idle, 2);
+        assertApproxEq(strategy.availableWithdrawLimit(_address), 0, 2);
+        assertApproxEq(strategy.maxWithdraw(_address), 0, 2);
+        assertApproxEq(strategy.maxRedeem(_address), 0, 2);
         assertLe(
-            strategy.maxRedeem(_address),
+            strategy.convertToAssets(strategy.maxRedeem(_address)),
             strategy.availableWithdrawLimit(_address)
         );
     }

--- a/src/test/e2e.t.sol
+++ b/src/test/e2e.t.sol
@@ -38,7 +38,7 @@ contract e2eTest is Setup {
         uint256 i;
 
         for (i; i < toMake; ++i) {
-            asset = new ERC20Mock("Mock asset", "mcAsset", user, 0);
+            asset = new ERC20Mock();
             yieldSource = new MockYieldSource(address(asset));
             IMockStrategy newStrategy = IMockStrategy(setUpStrategy());
 
@@ -133,7 +133,7 @@ contract e2eTest is Setup {
         uint256 i;
 
         for (i; i < toMake; ++i) {
-            asset = new ERC20Mock("Mock asset", "mcAsset", user, 0);
+            asset = new ERC20Mock();
             yieldSource = new MockYieldSource(address(asset));
             IMockStrategy newStrategy = IMockStrategy(setUpStrategy());
 
@@ -247,7 +247,7 @@ contract e2eTest is Setup {
         uint256 i;
 
         for (i; i < toMake; ++i) {
-            asset = new ERC20Mock("Mock asset", "mcAsset", user, 0);
+            asset = new ERC20Mock();
             yieldSource = new MockYieldSource(address(asset));
             IMockStrategy newStrategy = IMockStrategy(setUpStrategy());
 

--- a/src/test/utils/Setup.sol
+++ b/src/test/utils/Setup.sol
@@ -52,7 +52,7 @@ contract Setup is ExtendedTest, IEvents {
         tokenizedStrategy = new TokenizedStrategy();
 
         // create asset we will be using as the underlying asset
-        asset = new ERC20Mock("Mock asset", "mcAsset", user, 0);
+        asset = new ERC20Mock();
 
         // create a mock yield source to deposit into
         yieldSource = new MockYieldSource(address(asset));


### PR DESCRIPTION
## Description

- Use convertToShares instead of previewWithdraw in maxRedeem.
- This will round down instead of up. Eliminating a potential issue caused by double rounding in which the convertToAssets in `redeem` will return a value slightly higher than the avialableWithdrawLimit
- also bumped OZ version

## Checklist

- [x] I have run solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
- [x] I have updated the SPECIFICATION.md for any relevant changes
