### PR TITLE
chore: match vault abi

### DIFF
--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -781,6 +781,17 @@ contract TokenizedStrategy {
     }
 
     /**
+     * @notice Accepts a `maxLoss` variable in order to match the multi
+     * strategy vaults ABI.
+     */
+    function maxWithdraw(
+        address owner,
+        uint256 /*maxLoss*/
+    ) external view returns (uint256) {
+        return _maxWithdraw(_strategyStorage(), owner);
+    }
+
+    /**
      * @notice Total number of strategy shares that can be
      * redeemed from the strategy by `owner`, where `owner`
      * corresponds to the msg.sender of a {redeem} call.
@@ -789,6 +800,17 @@ contract TokenizedStrategy {
      * @return _maxRedeem Max amount of shares that can be redeemed.
      */
     function maxRedeem(address owner) external view returns (uint256) {
+        return _maxRedeem(_strategyStorage(), owner);
+    }
+
+    /**
+     * @notice Accepts a `maxLoss` variable in order to match the multi
+     * strategy vaults ABI.
+     */
+    function maxRedeem(
+        address owner,
+        uint256 /*maxLoss*/
+    ) external view returns (uint256) {
         return _maxRedeem(_strategyStorage(), owner);
     }
 

--- a/src/interfaces/ITokenizedStrategy.sol
+++ b/src/interfaces/ITokenizedStrategy.sol
@@ -72,6 +72,16 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
         uint256 maxLoss
     ) external returns (uint256);
 
+    function maxWithdraw(
+        address owner,
+        uint256 /*maxLoss*/
+    ) external view returns (uint256);
+
+    function maxRedeem(
+        address owner,
+        uint256 /*maxLoss*/
+    ) external view returns (uint256);
+
     /*//////////////////////////////////////////////////////////////
                         MODIFIER HELPERS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
## Description

Adds a `maxLoss` variable for maxRedeem and maxWithdraw that matches the multi strategy vaults ABI and the withdraw and redeem functions. Variable is currently not used.

Fixes # (issue)

## Checklist

- [x] I have run solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
- [x] I have updated the SPECIFICATION.md for any relevant changes
