### PR TITLE
fix: deposit flow

### DIFF
--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -840,12 +840,14 @@ contract TokenizedStrategy {
         uint256 assets,
         Math.Rounding _rounding
     ) internal view returns (uint256) {
-        // Saves an extra SLOAD if totalAssets() is non-zero.
-        uint256 totalAssets_ = _totalAssets(S);
+        // Saves an extra SLOAD if values are non-zero.
         uint256 totalSupply_ = _totalSupply(S);
+        // If supply is 0, PPS = 1.
+        if (totalSupply_ == 0) return assets;
 
+        uint256 totalAssets_ = _totalAssets(S);
         // If assets are 0 but supply is not PPS = 0.
-        if (totalAssets_ == 0) return totalSupply_ == 0 ? assets : 0;
+        if (totalAssets_ == 0) return 0;
 
         return assets.mulDiv(totalSupply_, totalAssets_, _rounding);
     }

--- a/src/test/Accounting.t.sol
+++ b/src/test/Accounting.t.sol
@@ -639,7 +639,6 @@ contract AccountingTest is Setup {
         // Should still have shares but no assets
         checkStrategyTotals(strategy, 0, 0, 0, _amount);
 
-        assertEq(asset.balanceOf(_address), 0);
         assertEq(strategy.balanceOf(_address), _amount);
         assertEq(asset.balanceOf(address(strategy)), 0);
         assertEq(asset.balanceOf(address(yieldSource)), 0);
@@ -682,7 +681,6 @@ contract AccountingTest is Setup {
         // Should still have shares but no assets
         checkStrategyTotals(strategy, 0, 0, 0, _amount);
 
-        assertEq(asset.balanceOf(_address), 0);
         assertEq(strategy.balanceOf(_address), _amount);
         assertEq(asset.balanceOf(address(strategy)), 0);
         assertEq(asset.balanceOf(address(yieldSource)), 0);

--- a/src/test/Accounting.t.sol
+++ b/src/test/Accounting.t.sol
@@ -613,4 +613,90 @@ contract AccountingTest is Setup {
 
         assertEq(asset.balanceOf(address(yieldSource)), _amount);
     }
+
+    function test_deposit_zeroAssetsPositiveSupply_reverts(
+        address _address,
+        uint256 _amount
+    ) public {
+        _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
+        vm.assume(
+            _address != address(0) &&
+                _address != address(strategy) &&
+                _address != address(yieldSource)
+        );
+
+        setFees(0, 0);
+        mintAndDepositIntoStrategy(strategy, _address, _amount);
+
+        uint256 toLoose = _amount;
+        // Simulate a loss.
+        vm.prank(address(yieldSource));
+        asset.transfer(address(69), toLoose);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        // Should still have shares but no assets
+        checkStrategyTotals(strategy, 0, 0, 0, _amount);
+
+        assertEq(asset.balanceOf(_address), 0);
+        assertEq(strategy.balanceOf(_address), _amount);
+        assertEq(asset.balanceOf(address(strategy)), 0);
+        assertEq(asset.balanceOf(address(yieldSource)), 0);
+
+        asset.mint(_address, _amount);
+        vm.prank(_address);
+        asset.approve(address(strategy), _amount);
+
+        vm.expectRevert("ZERO_SHARES");
+        vm.prank(_address);
+        strategy.deposit(_amount, _address);
+
+        assertEq(strategy.convertToAssets(_amount), 0);
+        assertEq(strategy.convertToShares(_amount), 0);
+        assertEq(strategy.pricePerShare(), 0);
+    }
+
+    function test_mint_zeroAssetsPositiveSupply_reverts(
+        address _address,
+        uint256 _amount
+    ) public {
+        _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
+        vm.assume(
+            _address != address(0) &&
+                _address != address(strategy) &&
+                _address != address(yieldSource)
+        );
+
+        setFees(0, 0);
+        mintAndDepositIntoStrategy(strategy, _address, _amount);
+
+        uint256 toLoose = _amount;
+        // Simulate a loss.
+        vm.prank(address(yieldSource));
+        asset.transfer(address(69), toLoose);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        // Should still have shares but no assets
+        checkStrategyTotals(strategy, 0, 0, 0, _amount);
+
+        assertEq(asset.balanceOf(_address), 0);
+        assertEq(strategy.balanceOf(_address), _amount);
+        assertEq(asset.balanceOf(address(strategy)), 0);
+        assertEq(asset.balanceOf(address(yieldSource)), 0);
+
+        asset.mint(_address, _amount);
+        vm.prank(_address);
+        asset.approve(address(strategy), _amount);
+
+        vm.expectRevert("ZERO_ASSETS");
+        vm.prank(_address);
+        strategy.mint(_amount, _address);
+
+        assertEq(strategy.convertToAssets(_amount), 0);
+        assertEq(strategy.convertToShares(_amount), 0);
+        assertEq(strategy.pricePerShare(), 0);
+    }
 }

--- a/src/test/Accounting.t.sol
+++ b/src/test/Accounting.t.sol
@@ -439,10 +439,10 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = (_amount * _lossFactor) / MAX_BPS;
+        uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         vm.expectRevert("too much loss");
         vm.prank(_address);
@@ -465,13 +465,13 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = (_amount * _lossFactor) / MAX_BPS;
+        uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
-        uint256 expectedOut = _amount - toLoose;
+        uint256 expectedOut = _amount - toLose;
         // Withdraw the full amount before the loss is reported.
         vm.prank(_address);
         strategy.withdraw(_amount, _address, _address, _lossFactor);
@@ -499,13 +499,13 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = (_amount * _lossFactor) / MAX_BPS;
+        uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
-        uint256 expectedOut = _amount - toLoose;
+        uint256 expectedOut = _amount - toLose;
         // Withdraw the full amount before the loss is reported.
         vm.prank(_address);
         strategy.redeem(_amount, _address, _address);
@@ -533,10 +533,10 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = (_amount * _lossFactor) / MAX_BPS;
+        uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         vm.expectRevert("too much loss");
         vm.prank(_address);
@@ -559,13 +559,13 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = (_amount * _lossFactor) / MAX_BPS;
+        uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
-        uint256 expectedOut = _amount - toLoose;
+        uint256 expectedOut = _amount - toLose;
 
         // First set it to just under the expected loss.
         vm.expectRevert("too much loss");
@@ -628,10 +628,10 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = _amount;
+        uint256 toLose = _amount;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         vm.prank(keeper);
         strategy.report();
@@ -670,10 +670,10 @@ contract AccountingTest is Setup {
         setFees(0, 0);
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
-        uint256 toLoose = _amount;
+        uint256 toLose = _amount;
         // Simulate a loss.
         vm.prank(address(yieldSource));
-        asset.transfer(address(69), toLoose);
+        asset.transfer(address(69), toLose);
 
         vm.prank(keeper);
         strategy.report();


### PR DESCRIPTION
## Description

Still allow deposits to work if totalSupply == 0 but totalAssets > 0. Just make PPS == 1.

This can happen due to the profit unlocking if all shares are redeemed while some profit is still unlocking, at the end of the unlock time totalAssets >0 but totalSupply == 0.

- Still return 0 in convertToShares if totalSupply > 0 but totalAssets == 0. Meaning a full loss.
- Optimize to not cache totalAssets_ until needed

- Add the check for share receiver to the maxDeposit/maxMint checks instead. So that the view functions are more accurate.
- Update the variable name from `owner` => `receiver` to be more accurate
Fixes # (issue)

## Checklist

- [x] I have run solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
- [x] I have updated the SPECIFICATION.md for any relevant changes
