### PR TITLE
fix: permit constants

### DIFF
--- a/src/TokenizedStrategy.sol
+++ b/src/TokenizedStrategy.sol
@@ -2023,7 +2023,7 @@ contract TokenizedStrategy {
                     keccak256(
                         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
                     ),
-                    keccak256(bytes("Yearn Vault")),
+                    keccak256("Yearn Vault"),
                     keccak256(bytes(API_VERSION)),
                     block.chainid,
                     address(this)


### PR DESCRIPTION
## Description

Don't cast the name through bytes before keccack

Fixes # (issue)

## Checklist

- [ ] I have run solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
- [ ] I have updated the SPECIFICATION.md for any relevant changes
